### PR TITLE
chore(cache): refactor uv cache usage in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,25 +22,13 @@ jobs:
       - name: Setup | Install uv # https://docs.astral.sh/uv/guides/integration/github/#using-uv-in-github-actions
         uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          enable-cache: false
 
-      - name: Setup | Install Python and hash version # https://docs.astral.sh/uv/guides/integration/github/#setting-up-python
-        run: |
-          uv python install
-          echo "PYTHON_VERSION_HASH=$(uvx python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-
-      - name: Setup | Restore pre-commit cache # https://pre-commit.com/#github-actions-example
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PYTHON_VERSION_HASH }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Setup | Install Python # https://docs.astral.sh/uv/guides/integration/github/#setting-up-python
+        run: uv python install
 
       - name: Setup | Install pre-commit # https://pre-commit.com/#usage-in-continuous-integration
         run: uv tool install pre-commit
 
       - name: Run | Test
         run: make test
-
-      - name: Post Setup | Minimize uv cache # https://docs.astral.sh/uv/guides/integration/github/#caching
-        run: uv cache prune --ci

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -21,11 +21,16 @@ jobs:
       - name: Setup | Install uv # https://docs.astral.sh/uv/guides/integration/github/#using-uv-in-github-actions
         uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5
         with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          enable-cache: false
 
       - name: Setup | Install Python # https://docs.astral.sh/uv/guides/integration/github/#setting-up-python
         run: uv python install
+
+      - name: Setup | Restore uv cache for docs
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ${{ github.workspace }}/.uv-cache
+          key: uv-docs-${{ hashFiles('uv.lock') }}
 
       - name: Run | Build static HTML documentation using Sphinx
         id: build
@@ -36,9 +41,6 @@ jobs:
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/build/html/
-
-      - name: Post Setup | Minimize uv cache # https://docs.astral.sh/uv/guides/integration/github/#caching
-        run: uv cache prune --ci
 
   # Deployment job
   deploy-docs:


### PR DESCRIPTION
Because of [restrictions for accessing a cache](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), caching is only effective when a workflow runs either on the default branch (main) or several times on a feature branch/pull request.